### PR TITLE
Prevent bad access errors when `part` is `undefined`

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -376,7 +376,7 @@ internals.reference = function (name) {
 
 internals.evaluate = function (part, context) {
 
-    if (part === null) {
+    if (part === null || part === undefined) {
         return null;
     }
 


### PR DESCRIPTION
This is to resolve this issue that I'm running into: https://github.com/hapijs/joi/issues/2974#issuecomment-1678148015

There may be a deeper issue worth resolving with regard to `evaluate()` being called with `part === undefined`, but I haven't dug that deep. 

Either way, I'd expect that it's worth handling this situation gracefully (as is already the case when `part === null`) rather than letting the type error occur on line 385 where it attempts to call `part[internals.symbol]`.